### PR TITLE
Endpoints to return assoc fields

### DIFF
--- a/libs/dbLib2/DataGraph.ts
+++ b/libs/dbLib2/DataGraph.ts
@@ -67,6 +67,7 @@ export interface ISortField<T extends IEnt = IEnt> {
   field: (keyof T | string);
   order: 'asc' | 'desc';
 }
+export interface IAssociatedEntIds extends IHasId, IHasData {}
 
 export function isIEntInsert (obj: any): obj is IEntInsert {
   return '_type' in obj;
@@ -159,12 +160,14 @@ export interface IDataGraph {
    * @param entId
    * @param assocType
    * @param direction
+   * @param assocFields data fields to fetch from each association
    */
   listAssociatedEntityIds (
     entId: Id,
     assocType: Type,
     direction: 'forward' | 'backward',
-  ): Promise<Id[]>;
+    assocFields?: string[],
+  ): Promise<IAssociatedEntIds[]>;
   deleteAssocs (ids: Id[]): Promise<number>;
   dropDb (): Promise<any>;
   close (): Promise<void>;

--- a/libs/dbLib2/_test/MongoGraphTest.ts
+++ b/libs/dbLib2/_test/MongoGraphTest.ts
@@ -2,6 +2,7 @@ import * as _ from 'lodash';
 import { expect } from 'chai';
 import 'mocha';
 import { IDataGraph, DataGraph, Type } from '../DataGraph';
+import { Logger } from 'mongodb';
 
 describe('MongoGraphTest', async function () {
   let g: IDataGraph;
@@ -287,15 +288,23 @@ describe('MongoGraphTest', async function () {
       let idsFound =
         await g.listAssociatedEntityIds(ids[2], ASSOC_TYPE2, 'forward');
       expect(idsFound).to.have.lengthOf(2);
-      expect(idsFound).to.deep.include(ids[2]);
-      expect(idsFound).to.deep.include(ids[3]);
+      expect(idsFound).to.deep.include({ _id: ids[2] });
+      expect(idsFound).to.deep.include({ _id: ids[3] });
+    });
+
+    it('find associated ent ids, with assoc fields', async function () {
+      let idsFound =
+        await g.listAssociatedEntityIds(ids[4], ASSOC_TYPE1, 'forward', ['d']);
+      expect(idsFound).to.have.lengthOf(1);
+      console.log(idsFound);
+      expect(idsFound).to.deep.include({ _id: ids[0], d: 'data1' });
     });
 
     it('find associated ent ids, backward', async function () {
       let idsFound =
         await g.listAssociatedEntityIds(ids[1], ASSOC_TYPE2, 'backward');
       expect(idsFound).to.have.lengthOf(1);
-      expect(idsFound).to.deep.include(ids[0]);
+      expect(idsFound).to.deep.include({ _id: ids[0] });
     });
 
     it('find associated ent ids, backward, nonexisting', async function () {

--- a/testLambda/bills.json
+++ b/testLambda/bills.json
@@ -10,7 +10,8 @@
         "field": [
             "congress",
             "billType",
-            "billNumber"
+            "billNumber",
+            "cosponsors#date"
         ]
     },
     "pathParameters": null,

--- a/testLambda/ids.json
+++ b/testLambda/ids.json
@@ -12,8 +12,8 @@
             "congress",
             "billType",
             "billNumber",
-            "sponsors",
-            "tags"
+            "cosponsors#date",
+            "tagIds"
         ],
         "id": [
             "fc46042f-989f-49a8-8e00-a5d26c0c3ba1",


### PR DESCRIPTION
Originally, one can query virtual fields such as `cosponsorIds` to get the associated entity IDs as **an array of IDs**.

This behavior will be changed by this PR. Now one may query virtual fields such as `cosponsors` and get back **an array of objects, each having a _id field**. Optionally, one may query `cosponsors#date` to fetch the **date** field of the assoc. In this case, the returned objects will each contain an additional `date` field.

General case: `virtual_field_name#assoc_field1#assoc_field2#...`

The old virtual fields are kept for backward compatibility. Once the frontend adopts the new virtual fields, we should remove the old fields.

Affected virtual fields:
- sponsorIds --> sponsors
- cosponsorIds --> cosponsors
- tagIds --> tags
- sponsoredBillIds --> sponsoredBills
- cosponsoredBillIds --> cosponsoredBills

#26 